### PR TITLE
Fix installation issue and add assertion to bootstrapping example. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,8 +774,9 @@ configure_file(OpenFHEConfigVersion.cmake.in
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/OpenFHEConfig.cmake"
   "${PROJECT_BINARY_DIR}/OpenFHEConfigVersion.cmake"
+  "${PROJECT_BINARY_DIR}/OpenFHETargets.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 
 # Install the export set for use with the install-tree
-install(EXPORT OpenFHETargets DESTINATION
+install(TARGETS Thrust rmm spdlog_header_only EXPORT OpenFHETargets DESTINATION
   "${INSTALL_CMAKE_DIR}" COMPONENT dev)

--- a/src/pke/examples/advanced-ckks-bootstrapping-gpu.cpp
+++ b/src/pke/examples/advanced-ckks-bootstrapping-gpu.cpp
@@ -525,5 +525,9 @@ void BootstrapExample(uint32_t numSlots) {
     // std::cout << "Output after bootstrapping \n\t" << result << std::endl;
     std::cout << "Output precision after bootstrapping \n\t" << result->GetEncodingParams()->GetPlaintextModulus() - result->GetLogError() << std::endl;
 
+    std::vector<double> real_val = result->GetRealPackedValue();
+    for (size_t i = 0; i < numSlots; i++) {
+        assert (std::abs(real_val[i] - x[i]) < 5e-3);
+    }
     // return;
 }

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -23,3 +23,20 @@ option(BUILD_TESTS OFF)
 # set(BUILD_BENCHMARKS OFF)
 # target_link_libraries(rmm benchmark::benchmark)
 FetchContent_MakeAvailable(rmm)
+
+# Some include paths do not exist
+function(filter_include_paths INPUT_VAR OUTPUT_VAR)
+  set(filtered_paths "")
+  foreach(path IN LISTS ${INPUT_VAR})
+    if(EXISTS "${path}")
+      list(APPEND filtered_paths "${path}")
+    endif()
+  endforeach()
+  set(${OUTPUT_VAR} "${filtered_paths}" PARENT_SCOPE)
+endfunction()
+
+get_target_property(RMM_INCLUDE_DIRS rmm INTERFACE_INCLUDE_DIRECTORIES)
+filter_include_paths(RMM_INCLUDE_DIRS RMM_INCLUDE_DIRS_FILTERED)
+set_target_properties(rmm PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${RMM_INCLUDE_DIRS_FILTERED}"
+)


### PR DESCRIPTION
Hi Leo, 

Thank you for sharing this GPU extension for OpenFHE! I've found some installation issues and missing assertions in the bootstrapping example when I attempted to use this library. Thus, I've created this PR to fix them. 

This PR modifies the CMakeLists and adds some assertions in `src/pke/examples/advanced-ckks-bootstrapping-gpu.cpp`. The installation is tested with the docker image [nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04](https://hub.docker.com/layers/nvidia/cuda/12.4.1-cudnn-devel-ubuntu22.04/images/sha256-0a434eff1826693c1e2a669b20062f9995e73ed3456cdb70416d7ba9c1e3d1f5) with CMake 3.22.1. 

Feel free to take a look and give any suggestions :)